### PR TITLE
Updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-PyAudio == 0.2.11
+PyAudio == 0.2.14
 mido == 1.2.10
+rtmidi == 2.5.0
+python-rtmidi == 1.5.8


### PR DESCRIPTION
I also bumped the version of PyAudio, since 0.2.14 comes with precompiled wheels for windows